### PR TITLE
Resolve duplicate declaration of package curl

### DIFF
--- a/manifests/packages.pp
+++ b/manifests/packages.pp
@@ -10,9 +10,7 @@ class rocketchat::packages(
     before     => Exec['npm install']
   }
 
-  package { 'curl':
-    ensure => installed,
-  }
+  package { 'curl': }
 
   package { 'graphicsmagick':
     ensure => installed,


### PR DESCRIPTION
sagit:puppet already ensures the presence of package 'curl',
causing the error:

  `Package[curl] is already declared …; cannot redeclare`

The initial declaration is in

  sagit:puppet/manifests/default_node.pp:9
  `ensure_packages($params[packages])`

with the package params being defined in

  hieradata/common.yaml:53
  `- curl`

The removal of `ensure => installed` should resolve the duplicate declaration.

See discussion at
https://seekingalpha.slack.com/archives/CTNFNEPFA/p1598799643009000?thread_ts=1598796876.008700&cid=CTNFNEPFA